### PR TITLE
Writing error file in binary mode

### DIFF
--- a/plantuml.py
+++ b/plantuml.py
@@ -68,9 +68,9 @@ def deflate_and_encode(plantuml_text):
 
 class PlantUML(object):
     """Connection to a PlantUML server with optional authentication.
-    
+
     All parameters are optional.
-    
+
     :param str url: URL to the PlantUML server image CGI. defaults to
                     http://www.plantuml.com/plantuml/img/
     :param dict basic_auth: This is if the plantuml server requires basic HTTP
@@ -91,7 +91,7 @@ class PlantUML(object):
                     httplib2.Http() constructor.
     :param dict request_opts: Extra options to be passed off to the
                     httplib2.Http().request() call.
-                    
+
     """
 
     def __init__(self, url, basic_auth={}, form_auth={},
@@ -152,7 +152,7 @@ class PlantUML(object):
     def get_url(self, plantuml_text):
         """Return the server URL for the image.
         You can use this URL in an IMG HTML tag.
-        
+
         :param str plantuml_text: The plantuml markup to render
         :returns: the plantuml server image URL
         """
@@ -160,7 +160,7 @@ class PlantUML(object):
 
     def processes(self, plantuml_text):
         """Processes the plantuml text into the raw PNG image data.
-        
+
         :param str plantuml_text: The plantuml markup to render
         :returns: the raw image data
         """
@@ -176,7 +176,7 @@ class PlantUML(object):
     def processes_file(self, filename, outfile=None, errorfile=None, directory=''):
         """Take a filename of a file containing plantuml text and processes
         it into a .png image.
-        
+
         :param str filename: Text file containing plantuml markup
         :param str outfile: Filename to write the output image to. If not
                     supplied, then it will be the input filename with the
@@ -198,7 +198,7 @@ class PlantUML(object):
         try:
             content = self.processes(data)
         except PlantUMLHTTPError as e:
-            err = open(path.join(directory, errorfile), 'w')
+            err = open(path.join(directory, errorfile), 'wb')
             err.write(e.content)
             err.close()
             return False


### PR DESCRIPTION
PlantUML server returns errors as images. Trying to write `bytes` into a file that is opened in text mode breaks in Python 3.